### PR TITLE
* Fix issue with separate boot pool and special characters

### DIFF
--- a/grub.d/05_zfs_linux.py
+++ b/grub.d/05_zfs_linux.py
@@ -437,7 +437,7 @@ class GrubLinuxEntry:
 
                 target = re.search(r'zedenv-(.*)/boot/*$', self.dirname)
             else:
-                target = re.search(r'zedenv-(\w*)@?/*$',
+                target = re.search(r'zedenv-(.*)@?/*$',
                                    grub_command("grub-mkrelpath", [self.dirname])[0])
         else:
             target = re.search(r'zedenv-(.*)/*$', self.dirname)


### PR DESCRIPTION
## Description

The change in the regex allows to use all special characters as a boot environment name.
Fixes #26

## Testing

- [x] Tested GRUB with zfsboot
- [ ] Tested GRUB without zfsboot
