### PR TITLE
[WIP] Fixed wrong name parsing (Fixes #26)

### DIFF
--- a/grub.d/05_zfs_linux.py
+++ b/grub.d/05_zfs_linux.py
@@ -437,7 +437,7 @@ class GrubLinuxEntry:
 
                 target = re.search(r'zedenv-(.*)/boot/*$', self.dirname)
             else:
-                target = re.search(r'zedenv-([a-zA-Z0-9_-]+)@?/*$',
+                target = re.search(r'zedenv-([a-zA-Z0-9_\-\.]+)@?/*$',
                                    grub_command("grub-mkrelpath", [self.dirname])[0])
         else:
             target = re.search(r'zedenv-(.*)/*$', self.dirname)


### PR DESCRIPTION
- added dot-support for extra boot pool

## Description

Boot environments with a _dot_ in the name are not parsed correctly.
This must be fixed and tested for

-  [x] separate boot pool for kernel files (done)
-  [ ] separate partition for kernel files
-  [ ] same boot environment for data and kernel files

@johnramsden Can you please adjust the regex expression for your setup and test if a boot environment with a dot in the name works?