### PR TITLE
* Improve kernel sorting

### DIFF
--- a/grub.d/05_zfs_linux.py
+++ b/grub.d/05_zfs_linux.py
@@ -742,7 +742,7 @@ class Generator:
         Rather than using key based compare, it is simpler to use a comparator in this situation.
         """
 
-        regex = re.compile(r'-([0-9]+(\.[0-9]+)*)-')
+        regex = re.compile(r'-([0-9]+([\.|\-][0-9]+)*)-')
 
         version0 = regex.search(kernel0)
         version1 = regex.search(kernel1)


### PR DESCRIPTION
## Description

Small modification to the regex in order to consider the complete kernel number for version comparison. Fixes #31

## Testing

- [x] Tested GRUB with external pool for kernels
Shouldn't be that relevant as the code change is not configuration dependent.
